### PR TITLE
Update jsDelivr link and set default file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery-color-animation",
   "version": "1.5.1",
+  "jsdelivr": "jquery.animate-colors-min.js",
   "description": "Let foreground, background and border colors fade to another color.",
   "keywords": ["jquery-plugin", "ecosystem:jquery", "animation", "color", "colour", "effect"],
   "homepage": "http://www.bitstorm.org/jquery/color-animation/",


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I noticed that there is an old link at https://bitstorm.org/jquery/color-animation/, the correct link is https://cdn.jsdelivr.net/npm/jquery-color-animation@1.5.1/jquery.animate-colors-min.js.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery-color-animation.

I also set the default file to `jquery.animate-colors-min.js`.

Feel free to ping me if you have any questions regarding this change.